### PR TITLE
[Feat] #57 - 앨범 생성일 이후에 질문 순서대로 나오게 하기

### DIFF
--- a/Diptych/Diptych/Presentation/TodayDiptych/View/TodayDiptychView.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/View/TodayDiptychView.swift
@@ -25,14 +25,7 @@ struct TodayDiptychView: View {
             MainDiptychView()
             .ignoresSafeArea(edges: .top)
             .onAppear {
-                Task {
-                    await viewModel.fetchUser()
-                    await viewModel.setTodayPhoto()
-                    await viewModel.setUserCameraLoactionState()
-                    await viewModel.fetchTodayImage()
-                    await viewModel.fetchWeeklyCalender()
-                    await viewModel.fetchContents()
-                }
+                fetchData()
             }
             .onDisappear {
                 viewModel.weeklyData.removeAll()
@@ -50,13 +43,14 @@ struct TodayDiptychView: View {
                              Task {
                                  await viewModel.fetchTodayImage()
                                  await viewModel.fetchWeeklyCalender()
-                                 await viewModel.fetchContents()
                              }
                          }
                 }
             }
         }
     }
+
+    // MARK: - UI Components
 
     private func MainDiptychView() -> some View {
         ZStack {
@@ -77,7 +71,7 @@ struct TodayDiptychView: View {
                 .padding(.top, 35)
 
                 HStack(spacing: 0) {
-                    Text("\"\(viewModel.question)\"")
+                    Text("\(viewModel.question)")
                         .frame(height: 78, alignment: .topLeading)
                         .lineSpacing(6)
                         .font(.pretendard(.light, size: 28))
@@ -197,6 +191,19 @@ struct TodayDiptychView: View {
                     }
                 }
             }
+        }
+    }
+
+    // MARK: - Custom Methods
+
+    private func fetchData() {
+        Task {
+            await viewModel.fetchUser()
+            await viewModel.setTodayPhoto()
+            await viewModel.setUserCameraLoactionState()
+            await viewModel.fetchTodayImage()
+            await viewModel.fetchWeeklyCalender()
+            await viewModel.fetchContents()
         }
     }
 }

--- a/Diptych/Diptych/Presentation/TodayDiptych/View/TodayDiptychView.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/View/TodayDiptychView.swift
@@ -103,7 +103,6 @@ struct TodayDiptychView: View {
                                             }
                                     }
                                 }.onAppear {
-                                    
                                     imageCacheViewModel.firstImage = image.getUIImage(newSize: thumbSize)
                                 }
                         case .failure:

--- a/Diptych/Diptych/Presentation/TodayDiptych/View/TodayDiptychView.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/View/TodayDiptychView.swift
@@ -77,8 +77,7 @@ struct TodayDiptychView: View {
                 .padding(.top, 35)
 
                 HStack(spacing: 0) {
-                    Text("오늘 본 동그라미는?")
-//                    Text("\"\(viewModel.question)\"")
+                    Text("\"\(viewModel.question)\"")
                         .frame(height: 78, alignment: .topLeading)
                         .lineSpacing(6)
                         .font(.pretendard(.light, size: 28))

--- a/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
@@ -19,7 +19,6 @@ final class TodayDiptychViewModel: ObservableObject {
     @Published var isFirst = true
     @Published var weeklyData = [WeeklyData]()
     @Published var isLoading = false
-    @Published var contentDay = 0
     @Published var content: Content?
     @Published var todayPhoto: Photo?
     @Published var photoFirstURL = ""
@@ -144,7 +143,9 @@ final class TodayDiptychViewModel: ObservableObject {
             guard let startDate = data["startDate"] as? Timestamp else { return }
 
             let dateComponents = Calendar.current.dateComponents([.day], from: startDate.dateValue(), to: Date())
-            guard let order = dateComponents.day else { return }
+            guard var order = dateComponents.day else { return }
+
+            if order >= 24 { order -= 24 } // TODO: - 질문 개수에 따라 초기화
 
             let contentSnapshot = try await db.collection("contents")
                 .whereField("order", isEqualTo: order) 
@@ -159,7 +160,6 @@ final class TodayDiptychViewModel: ObservableObject {
     }
 
     func setTodayPhoto() async {
-        
         let (todayDate, _, _) = setTodayCalendar()
         let timestamp = Timestamp(date: todayDate)
         guard let albumId = currentUser?.coupleAlbumId else { return }

--- a/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
@@ -68,8 +68,6 @@ final class TodayDiptychViewModel: ObservableObject {
         } catch {
             print(error.localizedDescription)
         }
-
-        print(weeklyData)
     }
 
     func fetchTodayImage() async {

--- a/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
@@ -10,6 +10,10 @@ import Firebase
 import FirebaseFirestore
 import FirebaseStorage
 
+/*
+ 오늘 날짜 - 앨범 생성일 빼면 인덱스가 나오니까 그 인덱스대로 질문을 불러오면 안 되나? 30이 넘으면 계산해 주긴 해야겠지만...
+ */
+
 final class TodayDiptychViewModel: ObservableObject {
 
     // MARK: - Properties
@@ -141,11 +145,13 @@ final class TodayDiptychViewModel: ObservableObject {
                 .getDocuments()
 
             let data = daySnapshot.documents[0].data()
-            guard let contentDay = data["contentDay"] as? Int else { return }
-            self.contentDay = contentDay
+            guard let startDate = data["startDate"] as? Timestamp else { return }
+
+            let dateComponents = Calendar.current.dateComponents([.day], from: startDate.dateValue(), to: Date())
+            guard let order = dateComponents.day else { return }
 
             let contentSnapshot = try await db.collection("contents")
-                .whereField("order", isEqualTo: contentDay) // TODO: - 유저의 앨범과 연결
+                .whereField("order", isEqualTo: order) 
                 .getDocuments()
 
             self.content = try contentSnapshot.documents[0].data(as: Content.self)

--- a/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/ViewModel/TodayDiptychViewModel.swift
@@ -10,10 +10,6 @@ import Firebase
 import FirebaseFirestore
 import FirebaseStorage
 
-/*
- 오늘 날짜 - 앨범 생성일 빼면 인덱스가 나오니까 그 인덱스대로 질문을 불러오면 안 되나? 30이 넘으면 계산해 주긴 해야겠지만...
- */
-
 final class TodayDiptychViewModel: ObservableObject {
 
     // MARK: - Properties


### PR DESCRIPTION
## 📸 PR

🌱 작업한 브랜치
- feat/#67

## ✏️ 작업한 내용
- 앨범 생성한 날짜와 오늘 날짜를 비교해서 질문을 띄움
- 일단 질문이 24개밖에 없길래 일단 24개로 구현했어요!

## 📌 스크린샷
<!-- 작업한 뷰의 스크린샷을 올려주세요. -->
<!-- 이미지 크기를 30%로 줄여서 올려주세요. ex. <img src = "이미지 주소" width = 30%>-->
<img src = "https://github.com/DeveloperAcademy-POSTECH/MC3-Team8-Aing/assets/108191001/7680d305-47de-4caf-a9d0-9f4e48b11b59" width = 30%>

## 📮 관련 이슈
- Resolved: #67 
