### PR TITLE
[Feat] PhotoDetailView 이미지 표시 최적화 (캐싱 등) 

### DIFF
--- a/Diptych/Diptych.xcodeproj/project.pbxproj
+++ b/Diptych/Diptych.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		445A47AF2A5FD6B6005573DC /* AlbumListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445A47AE2A5FD6B6005573DC /* AlbumListView.swift */; };
 		44671A212A6BE3D000C9C99A /* FirebaseMananger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44671A202A6BE3D000C9C99A /* FirebaseMananger.swift */; };
+		447E05012A79549F005AACE7 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447E05002A79549E005AACE7 /* ImageCacheManager.swift */; };
 		44852D2F2A6FBA430074D3D4 /* LottieUIViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44852D2E2A6FBA430074D3D4 /* LottieUIViews.swift */; };
 		44852D312A6FBC120074D3D4 /* LoadingLottie.json in Resources */ = {isa = PBXBuildFile; fileRef = 44852D302A6FBC120074D3D4 /* LoadingLottie.json */; };
 		44852D332A7012590074D3D4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44852D322A7012590074D3D4 /* UIColor+.swift */; };
@@ -132,6 +133,7 @@
 /* Begin PBXFileReference section */
 		445A47AE2A5FD6B6005573DC /* AlbumListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListView.swift; sourceTree = "<group>"; };
 		44671A202A6BE3D000C9C99A /* FirebaseMananger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMananger.swift; sourceTree = "<group>"; };
+		447E05002A79549E005AACE7 /* ImageCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		44852D2E2A6FBA430074D3D4 /* LottieUIViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieUIViews.swift; sourceTree = "<group>"; };
 		44852D302A6FBC120074D3D4 /* LoadingLottie.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = LoadingLottie.json; sourceTree = "<group>"; };
 		44852D322A7012590074D3D4 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 			children = (
 				AB2AC21D2A5F28E900B162E1 /* NameSpace */,
 				44DE9B962A67DCDD00E6615B /* TransformImageBasedOnContainerView.swift */,
+				447E05002A79549E005AACE7 /* ImageCacheManager.swift */,
 				44671A202A6BE3D000C9C99A /* FirebaseMananger.swift */,
 			);
 			path = Util;
@@ -849,6 +852,7 @@
 				988A277F2A72351900A9B5C0 /* SecureInputView.swift in Sources */,
 				ABCB300D2A6D367F007724DC /* Photo.swift in Sources */,
 				44DE9B922A67DC6500E6615B /* CameraRepresentableView.swift in Sources */,
+				447E05012A79549F005AACE7 /* ImageCacheManager.swift in Sources */,
 				AB2AC1F32A5F097400B162E1 /* ProfileView.swift in Sources */,
 				4498B2362A6D37E00069F54A /* CameraViewModel.swift in Sources */,
 				9846144B2A69075E0043EAE9 /* ProfileSettingView.swift in Sources */,

--- a/Diptych/Diptych/Presentation/Archive/View/PhotoDetailView.swift
+++ b/Diptych/Diptych/Presentation/Archive/View/PhotoDetailView.swift
@@ -30,7 +30,6 @@ struct PhotoDetailView {
     
     @State var image1Image: UIImage?
     @State var image2Image: UIImage?
-    @State var isShouldShowPrevOrNext: Bool = false
 }
 
 // MARK: - View
@@ -39,7 +38,7 @@ extension PhotoDetailView: View {
     var body: some View {
         ZStack {
             Color.offWhite.edgesIgnoringSafeArea(.top)
-            
+
             VStack(spacing: 0) {
                 
                 //MARK: - [1] 해더
@@ -51,7 +50,7 @@ extension PhotoDetailView: View {
                         Text("\(currentIndex + 1)")
                             .italic()
                             .font(.custom(PretendardType.medium.rawValue, size: 16))
-                        //                            .foregroundColor(.systemSalmon)
+//                            .foregroundColor(.systemSalmon)
                         Text("번째 딥틱")
                     }//: HStack
                     .padding(.bottom,10)
@@ -64,89 +63,107 @@ extension PhotoDetailView: View {
                 .padding(.top,32)
                 .padding(.horizontal,13)
                 
-                //MARK: - [2] 질문
-                VStack(spacing: 0){
-                    HStack(spacing: 0){
-                        Text("\(question ?? "")")
-                            .font(.custom(PretendardType.light.rawValue, size: 24))
-                            .foregroundColor(.offBlack)
-                            .multilineTextAlignment(.leading)
-                            .padding(.leading, 17)
+                
+                    //MARK: - [2] 질문
+                    VStack(spacing: 0){
+                        HStack(spacing: 0){
+                            Text("\(question ?? "")")
+                                .font(.custom(PretendardType.light.rawValue, size: 24))
+                                .foregroundColor(.offBlack)
+                                .multilineTextAlignment(.leading)
+                                .padding(.leading, 17)
+                            Spacer()
+                        }//】 HStack
+                        .padding(.top,23)
                         Spacer()
-                    }//】 HStack
-                    .padding(.top,23)
-                    Spacer()
-                }//】 HStack
-                .padding(.top,23)
-                Spacer()
-            }//】 VStack
-            .frame(height: 120)
-            
-            /// [3] 사진 프레임
-            ZStack{
-                RoundedRectangle(cornerRadius: 0)
-                    .foregroundColor(Color.darkGray)
-                //                        .stroke(Color.lightGray, lineWidth: 1)
-                // .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .frame(width: 393, height: 393)
-                
-                HStack(spacing: 0) {
-                    HStack(spacing: 0) {
-                        if let image1Image, let image2Image {
-                            HStack(spacing: 0) {
-                                Image(uiImage: image1Image)
-                                    .resizable()
-                                    .frame(width: 196.5, height: 393)
-                                Image(uiImage: image2Image)
-                                    .resizable()
-                                    .frame(width: 196.5, height: 393)
+                    }//】 VStack
+                    .frame(height: 120)
+                    
+                    
+                    /// [3] 사진 프레임
+                    ZStack{
+                        RoundedRectangle(cornerRadius: 0)
+                            .foregroundColor(Color.darkGray)
+                            // .stroke(Color.lightGray, lineWidth: 1)
+                            // .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .frame(width: 393, height: 393)
+                        
+                        HStack(spacing: 0) {
+                            if let image1Image, let image2Image {
+                                HStack(spacing: 0) {
+                                    Image(uiImage: image1Image)
+                                        .resizable()
+                                        .frame(width: 196.5, height: 393)
+                                    Image(uiImage: image2Image)
+                                        .resizable()
+                                        .frame(width: 196.5, height: 393)
+                                }
+                                // .transition(isShouldShowPrevOrNext ? .slide : .identity)
+                                // .transition(.opacity)
+                                // .animation(.linear)
                             }
-                            // .transition(isShouldShowPrevOrNext ? .slide : .identity)
-                            // .transition(.opacity)
-                            // .animation(.linear)
+                            else {
+                                ProgressView()
+                            }
+                            ///왼쪽 사진
+                            // AsyncImage(url: imageUrl1) { image in
+                            //
+                            //     image
+                            //         .resizable()
+                            //         .frame(width: 196.5, height: 393)
+                            // } placeholder: {
+                            //     ProgressView()
+                            // }
+                            // .frame(width: 196.5)
+                            
+                            
+                            /// 오른쪽 사진
+                            // AsyncImage(url: imageUrl2) { image in
+                            //     image
+                            //         .resizable()
+                            //         .frame(width: 196.5, height: 393)
+                            // } placeholder: {
+                            //     ProgressView()
+                            // }
+                            // .frame(width: 196.5)
+                        }//】 HStack
+                        
+//                        ImageCell(imageUrl1: imageUrl1, imageUrl2: imageUrl2)
+//                            .environmentObject(VM)
+//                            .frame(maxWidth: .infinity)
+                        
+                        HStack(spacing: 0){
+                            if currentIndex > 0 {previousButton} else {EmptyView()} /// 이전 버튼
+                            Spacer()
+                            if currentIndex < VM.truePhotos.count - 1{nextButton} else {EmptyView()} /// 다음 버튼
                         }
-                        else {
-                            ProgressView()
-                        }
-                    }
-                    
-                }//】 HStack
+                        .padding(.horizontal,18)
+                        
+                    }//】 ZStack
+                    .frame(height: 393, alignment: .center)
+                    .frame(maxWidth: .infinity)
+                    .aspectRatio(1, contentMode: .fit)
                 
+                //MARK: - [4] 공유/ 좋아요 버튼
                 HStack(spacing: 0){
-                    if currentIndex > 0 {previousButton} else {EmptyView()} /// 이전 버튼
-                    Spacer()
-                    if currentIndex < VM.truePhotos.count - 1{nextButton} else {EmptyView()} /// 다음 버튼
-                    
-                }
-                .padding(.horizontal,18)
+                    ShareSheetView()
+//                    Image("imgShareBox")
+                        .foregroundColor(.offBlack)
+                        .frame(width: 30, height: 30)
+                        .padding(.leading, 70)
+                    Image("imgWhiteHeart")
+                        .foregroundColor(.offBlack)
+                        .frame(width: 30, height: 30)
+                        .padding(.horizontal, 80)
+                    Image("imgComment")
+                        .foregroundColor(.offBlack)
+                        .frame(width: 30, height: 30)
+                        .padding(.trailing, 70)
+                }//】 HStack
+                .frame(height: 100)
+                .padding(.bottom,100)
                 
-                
-                
-            }//】 ZStack
-            .frame(height: 393, alignment: .center)
-            .frame(maxWidth: .infinity)
-            .aspectRatio(1, contentMode: .fit)
-            // .transition(.move(edge: .leading)) // 슬라이드 애니메이션을 적용합니다.
-            // .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
-            
-            //MARK: - [4] 공유/ 좋아요 버튼
-            HStack(spacing: 0){
-                ShareSheetView()
-                //                    Image("imgShareBox")
-                    .foregroundColor(.offBlack)
-                    .frame(width: 30, height: 30)
-                    .padding(.leading, 70)
-                Image("imgWhiteHeart")
-                    .foregroundColor(.offBlack)
-                    .frame(width: 30, height: 30)
-                    .padding(.horizontal, 80)
-                Image("imgComment")
-                    .foregroundColor(.offBlack)
-                    .frame(width: 30, height: 30)
-                    .padding(.trailing, 70)
-            }//】 HStack
-            .frame(height: 100)
-            .padding(.bottom,100)
+            } // VStack
             
         } // ZStack
         .onAppear {
@@ -157,7 +174,6 @@ extension PhotoDetailView: View {
         }
     }//】 Body
 }
-
 
 // MARK: - 이미지 셀
 //struct ImageCell: View {
@@ -267,13 +283,28 @@ extension PhotoDetailView {
     }
     
     /// 사진 상세뷰 업데이트
-    private func updateViewWithCurrentIndex() {
-        self.date = VM.truePhotos[currentIndex].date
-        self.image1 = VM.truePhotos[currentIndex].photoFirstURL
-        self.image2 = VM.truePhotos[currentIndex].photoSecondURL
-        self.question = VM.trueQuestions[currentIndex].question
-        // isFirstLoaded = false
-        // isSecondLoaded = false
+        private func updateViewWithCurrentIndex() {
+            self.date = VM.truePhotos[currentIndex].date
+            self.image1 = VM.truePhotos[currentIndex].photoFirstURL
+            self.image2 = VM.truePhotos[currentIndex].photoSecondURL
+            self.question = VM.trueQuestions[currentIndex].question
+        }
+    
+    /// 이미지 불러오기
+    func downloadImage() async {
+        if let image1 = image1 {
+            do {
+                let url = try await Storage.storage().reference(forURL: image1).downloadURL()
+                imageUrl1 = url
+            } catch { print(error.localizedDescription)}
+        }
+        
+        if let image2 = image2 {
+            do {
+                let url = try await Storage.storage().reference(forURL: image2).downloadURL()
+                imageUrl2 = url
+            } catch { print(error.localizedDescription)}
+        }
     }
     
     /// 이미지 불러오기 (메모리 캐싱)
@@ -315,7 +346,7 @@ extension PhotoDetailView {
             }
         }
     }
-
+    
     func textLabel(text: String) -> some View {
         return Text(text)
             .font(.custom(PretendardType.medium.rawValue, size: 16))
@@ -323,7 +354,7 @@ extension PhotoDetailView {
             .padding(.vertical, 7)
             .padding(.horizontal, 8)
             .background(Rectangle()
-                .fill(Color.lightGray)
+                        .fill(Color.lightGray)
             )
     }
 }

--- a/Diptych/Diptych/Presentation/Archive/View/PhotoDetailView.swift
+++ b/Diptych/Diptych/Presentation/Archive/View/PhotoDetailView.swift
@@ -51,7 +51,7 @@ extension PhotoDetailView: View {
                         Text("\(currentIndex + 1)")
                             .italic()
                             .font(.custom(PretendardType.medium.rawValue, size: 16))
-//                            .foregroundColor(.systemSalmon)
+                        //                            .foregroundColor(.systemSalmon)
                         Text("번째 딥틱")
                     }//: HStack
                     .padding(.bottom,10)
@@ -64,172 +64,89 @@ extension PhotoDetailView: View {
                 .padding(.top,32)
                 .padding(.horizontal,13)
                 
-                
-                    //MARK: - [2] 질문
-                    VStack(spacing: 0){
-                        HStack(spacing: 0){
-                            Text("\(question ?? "")")
-                                .font(.custom(PretendardType.light.rawValue, size: 24))
-                                .foregroundColor(.offBlack)
-                                .multilineTextAlignment(.leading)
-                                .padding(.leading, 17)
-                            Spacer()
-                        }//】 HStack
-                        .padding(.top,23)
+                //MARK: - [2] 질문
+                VStack(spacing: 0){
+                    HStack(spacing: 0){
+                        Text("\(question ?? "")")
+                            .font(.custom(PretendardType.light.rawValue, size: 24))
+                            .foregroundColor(.offBlack)
+                            .multilineTextAlignment(.leading)
+                            .padding(.leading, 17)
                         Spacer()
                     }//】 HStack
                     .padding(.top,23)
                     Spacer()
-                }//】 VStack
-                .frame(height: 120)
-                
-                
-                
-                /// [3] 사진 프레임
-                
-                ZStack{
-                    
-                    RoundedRectangle(cornerRadius: 0)
-                        .foregroundColor(Color.darkGray)
-                    //                        .stroke(Color.lightGray, lineWidth: 1)
-                        // .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .frame(width: 393, height: 393)
-                    
-                    
-                    
-                    HStack(spacing: 0) {
-                        HStack(spacing: 0) {
-                            if let image1Image, let image2Image {
-                                HStack(spacing: 0) {
-                                    Image(uiImage: image1Image)
-                                        .resizable()
-                                        .frame(width: 196.5, height: 393)
-                                    Image(uiImage: image2Image)
-                                        .resizable()
-                                        .frame(width: 196.5, height: 393)
-                                }
-                                // .transition(isShouldShowPrevOrNext ? .slide : .identity)
-                                // .transition(.opacity)
-                                // .animation(.linear)
-                            }
-                            else {
-                                ProgressView()
-                            }
-                        }
-                        
-                        // AsyncImage(url: imageUrl1) { phase in
-                        //     switch phase {
-                        //     case .success(let image):
-                        //         image
-                        //             .resizable()
-                        //             .frame(width: 196.5, height: 393)
-                        //             .onAppear {
-                        //                 print("image1 appeared:", Date().timeIntervalSince1970)
-                        //                 isFirstLoaded = true
-                        //                 print("all loaded?", isFirstLoaded && isSecondLoaded)
-                        //             }
-                        //             .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
-                        //         // Text("loaded")
-                        //
-                        //     case .failure(_):
-                        //         Text("error")
-                        //     case .empty:
-                        //         // placeholder
-                        //         ProgressView()
-                        //     @unknown default:
-                        //         Text("unknown")
-                        //     }
-                        // }.onAppear {
-                        //     print("onAppear: \(Date().timeIntervalSince1970)")
-                        // }.onChange(of: isFirstLoaded) { newValue in
-                        //     print("isFirstLoaded changed:", isFirstLoaded)
-                        // }
-                        //
-                        // AsyncImage(url: imageUrl2) { phase in
-                        //     switch phase {
-                        //     case .success(let image):
-                        //         image
-                        //             .resizable()
-                        //             .frame(width: 196.5, height: 393)
-                        //             .onAppear {
-                        //                 print("image2 appeared:", Date().timeIntervalSince1970)
-                        //                 isSecondLoaded = true
-                        //                 print("all loaded?", isFirstLoaded && isSecondLoaded)
-                        //             }
-                        //             .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
-                        //         // Text("loaded")
-                        //
-                        //     case .failure(_):
-                        //         Text("error")
-                        //     case .empty:
-                        //         // placeholder
-                        //         ProgressView()
-                        //     @unknown default:
-                        //         Text("unknown")
-                        //     }
-                        // }.onAppear {
-                        //     print("onAppear: \(Date().timeIntervalSince1970)")
-                        // }
-                        ///왼쪽 사진
-                        // AsyncImage(url: imageUrl1) { image in
-                        //
-                        //     image
-                        //         .resizable()
-                        //         .frame(width: 196.5, height: 393)
-                        // } placeholder: {
-                        //     ProgressView()
-                        // }
-                        // .frame(width: 196.5)
-                        
-                        
-                        /// 오른쪽 사진
-                        // AsyncImage(url: imageUrl2) { image in
-                        //     image
-                        //         .resizable()
-                        //         .frame(width: 196.5, height: 393)
-                        // } placeholder: {
-                        //     ProgressView()
-                        // }
-                        // .frame(width: 196.5)
-                    }//】 HStack
-                    
-                    HStack(spacing: 0){
-                        if currentIndex > 0 {previousButton} else {EmptyView()} /// 이전 버튼
-                        Spacer()
-                        if currentIndex < VM.truePhotos.count - 1{nextButton} else {EmptyView()} /// 다음 버튼
-                        
-                    }
-                    .padding(.horizontal,18)
-                    
-                    
-                    
-                }//】 ZStack
-                .frame(height: 393, alignment: .center)
-                .frame(maxWidth: .infinity)
-                .aspectRatio(1, contentMode: .fit)
-                // .transition(.move(edge: .leading)) // 슬라이드 애니메이션을 적용합니다.
-                // .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
-                
-                //MARK: - [4] 공유/ 좋아요 버튼
-                HStack(spacing: 0){
-                    ShareSheetView()
-                    //                    Image("imgShareBox")
-                        .foregroundColor(.offBlack)
-                        .frame(width: 30, height: 30)
-                        .padding(.leading, 70)
-                    Image("imgWhiteHeart")
-                        .foregroundColor(.offBlack)
-                        .frame(width: 30, height: 30)
-                        .padding(.horizontal, 80)
-                    Image("imgComment")
-                        .foregroundColor(.offBlack)
-                        .frame(width: 30, height: 30)
-                        .padding(.trailing, 70)
                 }//】 HStack
-                .frame(height: 100)
-                .padding(.bottom,100)
+                .padding(.top,23)
+                Spacer()
+            }//】 VStack
+            .frame(height: 120)
+            
+            /// [3] 사진 프레임
+            ZStack{
+                RoundedRectangle(cornerRadius: 0)
+                    .foregroundColor(Color.darkGray)
+                //                        .stroke(Color.lightGray, lineWidth: 1)
+                // .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(width: 393, height: 393)
                 
-            } // VStack
+                HStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        if let image1Image, let image2Image {
+                            HStack(spacing: 0) {
+                                Image(uiImage: image1Image)
+                                    .resizable()
+                                    .frame(width: 196.5, height: 393)
+                                Image(uiImage: image2Image)
+                                    .resizable()
+                                    .frame(width: 196.5, height: 393)
+                            }
+                            // .transition(isShouldShowPrevOrNext ? .slide : .identity)
+                            // .transition(.opacity)
+                            // .animation(.linear)
+                        }
+                        else {
+                            ProgressView()
+                        }
+                    }
+                    
+                }//】 HStack
+                
+                HStack(spacing: 0){
+                    if currentIndex > 0 {previousButton} else {EmptyView()} /// 이전 버튼
+                    Spacer()
+                    if currentIndex < VM.truePhotos.count - 1{nextButton} else {EmptyView()} /// 다음 버튼
+                    
+                }
+                .padding(.horizontal,18)
+                
+                
+                
+            }//】 ZStack
+            .frame(height: 393, alignment: .center)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+            // .transition(.move(edge: .leading)) // 슬라이드 애니메이션을 적용합니다.
+            // .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
+            
+            //MARK: - [4] 공유/ 좋아요 버튼
+            HStack(spacing: 0){
+                ShareSheetView()
+                //                    Image("imgShareBox")
+                    .foregroundColor(.offBlack)
+                    .frame(width: 30, height: 30)
+                    .padding(.leading, 70)
+                Image("imgWhiteHeart")
+                    .foregroundColor(.offBlack)
+                    .frame(width: 30, height: 30)
+                    .padding(.horizontal, 80)
+                Image("imgComment")
+                    .foregroundColor(.offBlack)
+                    .frame(width: 30, height: 30)
+                    .padding(.trailing, 70)
+            }//】 HStack
+            .frame(height: 100)
+            .padding(.bottom,100)
             
         } // ZStack
         .onAppear {
@@ -238,11 +155,9 @@ extension PhotoDetailView: View {
             // }
             downloadImageWithCache()
         }
-        .transition(.slide)
     }//】 Body
-    
-    
 }
+
 
 // MARK: - 이미지 셀
 //struct ImageCell: View {
@@ -401,10 +316,6 @@ extension PhotoDetailView {
         }
     }
 
-    
-    
-    
-    
     func textLabel(text: String) -> some View {
         return Text(text)
             .font(.custom(PretendardType.medium.rawValue, size: 16))

--- a/Diptych/Diptych/Presentation/Archive/View/PhotoDetailView.swift
+++ b/Diptych/Diptych/Presentation/Archive/View/PhotoDetailView.swift
@@ -28,10 +28,9 @@ struct PhotoDetailView {
         return formatter
     }()
     
-    
-    private let transaction: Transaction = .init(animation: .linear)
-    @State var isFirstLoaded: Bool = false
-    @State var isSecondLoaded: Bool = false
+    @State var image1Image: UIImage?
+    @State var image2Image: UIImage?
+    @State var isShouldShowPrevOrNext: Bool = false
 }
 
 // MARK: - View
@@ -40,7 +39,7 @@ extension PhotoDetailView: View {
     var body: some View {
         ZStack {
             Color.offWhite.edgesIgnoringSafeArea(.top)
-
+            
             VStack(spacing: 0) {
                 
                 //MARK: - [1] 해더
@@ -78,117 +77,143 @@ extension PhotoDetailView: View {
                         }//】 HStack
                         .padding(.top,23)
                         Spacer()
-                    }//】 VStack
-                    .frame(height: 120)
+                    }//】 HStack
+                    .padding(.top,23)
+                    Spacer()
+                }//】 VStack
+                .frame(height: 120)
+                
+                
+                
+                /// [3] 사진 프레임
+                
+                ZStack{
+                    
+                    RoundedRectangle(cornerRadius: 0)
+                        .foregroundColor(Color.darkGray)
+                    //                        .stroke(Color.lightGray, lineWidth: 1)
+                        // .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .frame(width: 393, height: 393)
                     
                     
-                    /// [3] 사진 프레임
                     
-                    ZStack{
-                        RoundedRectangle(cornerRadius: 0)
-                            .foregroundColor(Color.darkGray)
-                        //                        .stroke(Color.lightGray, lineWidth: 1)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        
+                    HStack(spacing: 0) {
                         HStack(spacing: 0) {
-                            
-                            AsyncImage(url: imageUrl1) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
+                            if let image1Image, let image2Image {
+                                HStack(spacing: 0) {
+                                    Image(uiImage: image1Image)
                                         .resizable()
                                         .frame(width: 196.5, height: 393)
-                                        .onAppear {
-                                            print("image1 appeared:", Date().timeIntervalSince1970)
-                                            isFirstLoaded = true
-                                            print("all loaded?", isFirstLoaded && isSecondLoaded)
-                                        }
-                                        .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
-                                    // Text("loaded")
-                                    
-                                case .failure(_):
-                                    Text("error")
-                                case .empty:
-                                    // placeholder
-                                    ProgressView()
-                                @unknown default:
-                                    Text("unknown")
-                                }
-                            }.onAppear {
-                                print("onAppear: \(Date().timeIntervalSince1970)")
-                            }.onChange(of: isFirstLoaded) { newValue in
-                                print("isFirstLoaded changed:", isFirstLoaded)
-                            }
-                            
-                            AsyncImage(url: imageUrl2) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
+                                    Image(uiImage: image2Image)
                                         .resizable()
                                         .frame(width: 196.5, height: 393)
-                                        .onAppear {
-                                            print("image2 appeared:", Date().timeIntervalSince1970)
-                                            isSecondLoaded = true
-                                            print("all loaded?", isFirstLoaded && isSecondLoaded)
-                                        }
-                                        .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
-                                    // Text("loaded")
-                                    
-                                case .failure(_):
-                                    Text("error")
-                                case .empty:
-                                    // placeholder
-                                    ProgressView()
-                                @unknown default:
-                                    Text("unknown")
                                 }
-                            }.onAppear {
-                                print("onAppear: \(Date().timeIntervalSince1970)")
+                                // .transition(isShouldShowPrevOrNext ? .slide : .identity)
+                                // .transition(.opacity)
+                                // .animation(.linear)
                             }
-                            ///왼쪽 사진
-                            // AsyncImage(url: imageUrl1) { image in
-                            //
-                            //     image
-                            //         .resizable()
-                            //         .frame(width: 196.5, height: 393)
-                            // } placeholder: {
-                            //     ProgressView()
-                            // }
-                            // .frame(width: 196.5)
-                            
-                            
-                            /// 오른쪽 사진
-                            // AsyncImage(url: imageUrl2) { image in
-                            //     image
-                            //         .resizable()
-                            //         .frame(width: 196.5, height: 393)
-                            // } placeholder: {
-                            //     ProgressView()
-                            // }
-                            // .frame(width: 196.5)
-                        }//】 HStack
-                        
-//                        ImageCell(imageUrl1: imageUrl1, imageUrl2: imageUrl2)
-//                            .environmentObject(VM)
-//                            .frame(maxWidth: .infinity)
-                        
-                        HStack(spacing: 0){
-                            if currentIndex > 0 {previousButton} else {EmptyView()} /// 이전 버튼
-                            Spacer()
-                            if currentIndex < VM.truePhotos.count - 1{nextButton} else {EmptyView()} /// 다음 버튼
+                            else {
+                                ProgressView()
+                            }
                         }
-                        .padding(.horizontal,18)
                         
-                    }//】 ZStack
-                    .frame(height: 393, alignment: .center)
-                    .frame(maxWidth: .infinity)
-                    .aspectRatio(1, contentMode: .fit)
-              
+                        // AsyncImage(url: imageUrl1) { phase in
+                        //     switch phase {
+                        //     case .success(let image):
+                        //         image
+                        //             .resizable()
+                        //             .frame(width: 196.5, height: 393)
+                        //             .onAppear {
+                        //                 print("image1 appeared:", Date().timeIntervalSince1970)
+                        //                 isFirstLoaded = true
+                        //                 print("all loaded?", isFirstLoaded && isSecondLoaded)
+                        //             }
+                        //             .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
+                        //         // Text("loaded")
+                        //
+                        //     case .failure(_):
+                        //         Text("error")
+                        //     case .empty:
+                        //         // placeholder
+                        //         ProgressView()
+                        //     @unknown default:
+                        //         Text("unknown")
+                        //     }
+                        // }.onAppear {
+                        //     print("onAppear: \(Date().timeIntervalSince1970)")
+                        // }.onChange(of: isFirstLoaded) { newValue in
+                        //     print("isFirstLoaded changed:", isFirstLoaded)
+                        // }
+                        //
+                        // AsyncImage(url: imageUrl2) { phase in
+                        //     switch phase {
+                        //     case .success(let image):
+                        //         image
+                        //             .resizable()
+                        //             .frame(width: 196.5, height: 393)
+                        //             .onAppear {
+                        //                 print("image2 appeared:", Date().timeIntervalSince1970)
+                        //                 isSecondLoaded = true
+                        //                 print("all loaded?", isFirstLoaded && isSecondLoaded)
+                        //             }
+                        //             .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
+                        //         // Text("loaded")
+                        //
+                        //     case .failure(_):
+                        //         Text("error")
+                        //     case .empty:
+                        //         // placeholder
+                        //         ProgressView()
+                        //     @unknown default:
+                        //         Text("unknown")
+                        //     }
+                        // }.onAppear {
+                        //     print("onAppear: \(Date().timeIntervalSince1970)")
+                        // }
+                        ///왼쪽 사진
+                        // AsyncImage(url: imageUrl1) { image in
+                        //
+                        //     image
+                        //         .resizable()
+                        //         .frame(width: 196.5, height: 393)
+                        // } placeholder: {
+                        //     ProgressView()
+                        // }
+                        // .frame(width: 196.5)
+                        
+                        
+                        /// 오른쪽 사진
+                        // AsyncImage(url: imageUrl2) { image in
+                        //     image
+                        //         .resizable()
+                        //         .frame(width: 196.5, height: 393)
+                        // } placeholder: {
+                        //     ProgressView()
+                        // }
+                        // .frame(width: 196.5)
+                    }//】 HStack
+                    
+                    HStack(spacing: 0){
+                        if currentIndex > 0 {previousButton} else {EmptyView()} /// 이전 버튼
+                        Spacer()
+                        if currentIndex < VM.truePhotos.count - 1{nextButton} else {EmptyView()} /// 다음 버튼
+                        
+                    }
+                    .padding(.horizontal,18)
+                    
+                    
+                    
+                }//】 ZStack
+                .frame(height: 393, alignment: .center)
+                .frame(maxWidth: .infinity)
+                .aspectRatio(1, contentMode: .fit)
+                // .transition(.move(edge: .leading)) // 슬라이드 애니메이션을 적용합니다.
+                // .opacity(isFirstLoaded && isSecondLoaded ? 1 : 0)
                 
                 //MARK: - [4] 공유/ 좋아요 버튼
                 HStack(spacing: 0){
                     ShareSheetView()
-//                    Image("imgShareBox")
+                    //                    Image("imgShareBox")
                         .foregroundColor(.offBlack)
                         .frame(width: 30, height: 30)
                         .padding(.leading, 70)
@@ -208,10 +233,12 @@ extension PhotoDetailView: View {
             
         } // ZStack
         .onAppear {
-            Task {
-                await downloadImage()
-            }
+            // Task {
+            //     await downloadImage()
+            // }
+            downloadImageWithCache()
         }
+        .transition(.slide)
     }//】 Body
     
     
@@ -284,7 +311,8 @@ extension PhotoDetailView {
         return Button {
             Task {
                 showPrevDetail()
-                await downloadImage()
+                // await downloadImage()
+                downloadImageWithCache()
             }
         } label: {
             IndexButton(icon: "chevron.left")
@@ -297,7 +325,8 @@ extension PhotoDetailView {
         return Button {
             Task {
                 showNextDetail()
-                await downloadImage()
+                // await downloadImage()
+                downloadImageWithCache()
             }
         } label: {
             IndexButton(icon: "chevron.right")
@@ -308,45 +337,67 @@ extension PhotoDetailView {
     
     /// 이전 버튼 로직
     func showPrevDetail() {
-            if currentIndex > 0{
-                self.currentIndex -= 1
-                updateViewWithCurrentIndex()
-            }
+        if currentIndex > 0{
+            self.currentIndex -= 1
+            updateViewWithCurrentIndex()
+        }
     }
     
     /// 다음 버튼 로직
     func showNextDetail() {
-            if currentIndex < VM.truePhotos.count - 1{
-                self.currentIndex += 1
-                updateViewWithCurrentIndex()
-            }
+        if currentIndex < VM.truePhotos.count - 1{
+            self.currentIndex += 1
+            updateViewWithCurrentIndex()
+        }
     }
     
     /// 사진 상세뷰 업데이트
-        private func updateViewWithCurrentIndex() {
-            self.date = VM.truePhotos[currentIndex].date
-            self.image1 = VM.truePhotos[currentIndex].photoFirstURL
-            self.image2 = VM.truePhotos[currentIndex].photoSecondURL
-            self.question = VM.trueQuestions[currentIndex].question
-            
-            // isFirstLoaded = false
-            // isSecondLoaded = false
-        }
+    private func updateViewWithCurrentIndex() {
+        self.date = VM.truePhotos[currentIndex].date
+        self.image1 = VM.truePhotos[currentIndex].photoFirstURL
+        self.image2 = VM.truePhotos[currentIndex].photoSecondURL
+        self.question = VM.trueQuestions[currentIndex].question
+        // isFirstLoaded = false
+        // isSecondLoaded = false
+    }
     
-    /// 이미지 불러오기
-    func downloadImage() async {
-        if let image1 = image1 {
-            do {
-                let url = try await Storage.storage().reference(forURL: image1).downloadURL()
-                imageUrl1 = url
-            } catch { print(error.localizedDescription)}
+    /// 이미지 불러오기 (메모리 캐싱)
+    func downloadImageWithCache() {
+        guard let image1, let image2 else {
+            return
         }
         
-        if let image2 = image2 {
-            do {
-                let url = try await Storage.storage().reference(forURL: image2).downloadURL()
-                imageUrl2 = url
-            } catch { print(error.localizedDescription)}
+        image1Image = nil
+        image2Image = nil
+        
+        Task {
+            if let cachedImageFirst = ImageCacheManager.shared.loadImageFromCache(urlAbsoluteString: image1) {
+                image1Image = cachedImageFirst
+                print("[DEBUG] image1: loaded from cache")
+                return
+            }
+            
+            image1Image = UIImage(data: try await FirebaseManager.shared.downloadImageDataFromFirebaseImageURL(urlAbsoluteString: image1))
+            
+            if let image1Image {
+                ImageCacheManager.shared.saveImageToCache(image: image1Image, urlAbsoluteString: image1)
+                print("[DEBUG] image1 saved to cache.")
+            }
+        }
+        
+        Task {
+            if let cachedImageSecond = ImageCacheManager.shared.loadImageFromCache(urlAbsoluteString: image2) {
+                image2Image = cachedImageSecond
+                print("i[DEBUG] mage2: loaded from cache")
+                return
+            }
+            
+            image2Image = UIImage(data: try await FirebaseManager.shared.downloadImageDataFromFirebaseImageURL(urlAbsoluteString: image2))
+            
+            if let image2Image {
+                ImageCacheManager.shared.saveImageToCache(image: image2Image, urlAbsoluteString: image2)
+                print("[DEBUG] image2 saved to cache.")
+            }
         }
     }
 
@@ -361,7 +412,7 @@ extension PhotoDetailView {
             .padding(.vertical, 7)
             .padding(.horizontal, 8)
             .background(Rectangle()
-                        .fill(Color.lightGray)
+                .fill(Color.lightGray)
             )
     }
 }

--- a/Diptych/Diptych/Presentation/TodayDiptych/ViewController/CameraViewController.swift
+++ b/Diptych/Diptych/Presentation/TodayDiptych/ViewController/CameraViewController.swift
@@ -680,7 +680,7 @@ class CameraViewController: UIViewController {
         // TODO: - print는 로딩 인디케이터 또는 작업상황 구분점임
         print("파일 업로드 시작....")
         LottieUIViews.shared.label.text = "이미지 파일 업로드 중..."
-        let url = try await FirebaseManager.shared.upload(data: data!, withName: "image_\(isFirst ? "first" : "second")_\(viewModel?.todayPhoto?.id ?? Date().formatted())")
+        let url = try await FirebaseManager.shared.upload(data: data!, withName: "image_\(isFirst ? "first" : "second")_\(viewModel?.todayPhoto?.id ?? UUID().uuidString)")
         print("파일 업로드 끝:", url?.absoluteString ?? "unknown URL")
         
         guard let url else {
@@ -706,7 +706,7 @@ class CameraViewController: UIViewController {
                let uploadThumb = mergedThumb.jpegData(compressionQuality: THUMB_COMPRESSION_QUALITY) {
                 LottieUIViews.shared.label.text = "섬네일 업로드 중..."
                 print("섬네일 업로드 시작....", halfAnotherThumb.size)
-                let thumbURL = try await FirebaseManager.shared.upload(data: uploadThumb, withName: "thumb_\(viewModel?.todayPhoto?.id ?? Date().formatted())")
+                let thumbURL = try await FirebaseManager.shared.upload(data: uploadThumb, withName: "thumb_\(viewModel?.todayPhoto?.id ?? UUID().uuidString)")
                 dictionary["thumbnail"] = thumbURL?.absoluteString
                 print("섬네일 업로드 끝")
             } else {

--- a/Diptych/Diptych/Util/FirebaseMananger.swift
+++ b/Diptych/Diptych/Util/FirebaseMananger.swift
@@ -44,4 +44,34 @@ class FirebaseManager {
         let document = collectionReference.document(documentId)
         try await document.updateData(dictionary)
     }
+    
+    /// 이미지 데이터 다운로드(Firebase 캐시 사용)
+    func downloadImageDataFromFirebase(childPath: String) async throws -> Data {
+        let reference = Storage.storage().reference().child(childPath)
+        
+        let url = try await reference.downloadURL()
+        return try Data(contentsOf: url)
+    }
+    
+    func downloadImageDataFromFirebaseImageURL(urlAbsoluteString: String) async throws -> Data {
+        let reference = Storage.storage().reference(forURL: urlAbsoluteString)
+        
+        let url = try await reference.downloadURL()
+        return try Data(contentsOf: url)
+    }
+    
+    func md5HashOfImageURL(from urlAbsoluteString: String) async throws -> String? {
+        let reference = Storage.storage().reference(forURL: urlAbsoluteString)
+        
+        let storageMetadata = try await reference.getMetadata()
+        return storageMetadata.md5Hash
+    }
+    
+    func uploadDateOfImageURL(from urlAbsoluteString: String) async throws -> Date? {
+        let reference = Storage.storage().reference(forURL: urlAbsoluteString)
+        
+        let storageMetadata = try await reference.getMetadata()
+        return storageMetadata.updated
+    }
 }
+

--- a/Diptych/Diptych/Util/ImageCacheManager.swift
+++ b/Diptych/Diptych/Util/ImageCacheManager.swift
@@ -1,0 +1,22 @@
+//
+//  ImageCacheMananger.swift
+//  Diptych
+//
+//  Created by 윤범태 on 2023/08/01.
+//
+
+import UIKit
+
+final class ImageCacheManager {
+    static private let memoryCache = NSCache<NSString, UIImage>()
+    static let shared = ImageCacheManager()
+    private init() {}
+    
+    func loadImageFromCache(urlAbsoluteString urlString: String) -> UIImage? {
+        ImageCacheManager.memoryCache.object(forKey: NSString(string: urlString))
+    }
+    
+    func saveImageToCache(image: UIImage, urlAbsoluteString urlString: String) {
+        ImageCacheManager.memoryCache.setObject(image, forKey: NSString(string: urlString))
+    }
+}


### PR DESCRIPTION
## 📸 PR

🌱 작업한 브랜치
- feat/#90

## ✏️ 작업한 내용
- 이미지 표시 방법 변경 (AsyncImage 외의 방법)
  - AsyncImage는 한계점이 많아서 대신 Firebase 내장 메서드를 사용했습니다.
  - 이미지 캐시 적용: 현재는 메모리 단에서만 저장하며 앱을 껐다 켜면 리셋됩니다.
- PhotoDetailView 기타 최적화

## 📌 스크린샷
<!-- 작업한 뷰의 스크린샷을 올려주세요. -->
<!-- 이미지 크기를 30%로 줄여서 올려주세요. ex. <img src = "이미지 주소" width = 30%>-->
<img src = "https://media.giphy.com/media/3avQxxLv5w1QdDKcWV/giphy.gif" width = 30%>

## 📮 관련 이슈
- Resolved: #
